### PR TITLE
New sandbox implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ $ composer require katanox/katanox-php
 
 ## Documentation
 
+### Setup
+First create a KatanoxApi Object
+```php 
+$katanox = new Katanox\KatanoxApi('your-api-key-here');
+```
 ### Get Availability
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $availabilityResource = $katanox->getAvailabilityResource();
 
 $q = new AvailabilityQuery();
@@ -44,10 +48,10 @@ $properties = $response->getData()->getProperties();
 // Get the next page
 $nextPage = $availabilityResource->next($response);
 $properties = $nextPage->getData()->getProperties();
+
 ```
 ### Create a new booking
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
 $booking = new Booking();
@@ -72,8 +76,8 @@ $reservation = new Reservation();
 $reservation->setCheckIn('2020-02-20')
 ->setCheckOut('2020-02-22')
 ->setPrice(new Price(1.0, 'EUR'))
-->setRatePlanId(1)
-->setUnitId(1)
+->setRatePlanId('ABCDEFGE')
+->setUnitId('TRCDNHGE')
 ->setGuests([$person]);
 
 $booking->setTotalPrice(1.0)
@@ -89,29 +93,26 @@ $newBooking = $createBookingResult->getBooking();
 
 ### Get a booking
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
-$booking = $bookingResource->getBooking('BOOKING_ID');
+$booking = $bookingResource->getBooking('<BOOKING_ID>');
 ```
 
 ### Cancel a booking
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
-$isCancelled = $bookingResource->cancelBooking('BOOKING_ID');
+$isCancelled = $bookingResource->cancelBooking('<BOOKING_ID>');
 ```
 
 ### Create a reservation
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
 $createReservationRequest = new CreateReservationRequest();
 
 $person = new Person();
-$person->setFirstName('fisrtName')
+$person->setFirstName('firstName')
 ->setLastName('lastName')
 ->setTitle('Mr')
 ->setBirthDate('2020-02-20')
@@ -122,12 +123,12 @@ $reservation = new Reservation();
 $reservation->setCheckIn('2020-02-20')
 ->setCheckOut('2020-02-22')
 ->setPrice(new Price(1.0, 'EUR'))
-->setRatePlanId(1)
-->setUnitId(1)
+->setRatePlanId('ABCDEFGE')
+->setUnitId('TRCDNHGE')
 ->setGuests([$person]);
 
 $createReservationRequest->setReservation($reservation)
-->setBookingId('BOOKING_ID');
+->setBookingId('<BOOKING_ID>');
 
 $createReservationResult = $bookingResource->createReservation($createReservationRequest);
 
@@ -137,16 +138,14 @@ $newReservation = $createReservationResult->getReservation();
 
 ### Update a reservation
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
 $updateReservation = new UpdateReservationRequest();
 
 
 // update the reservation
-
 $updateReservationRequest->setReservation($reservation);
-$updateReservationRequest->setBookingId('BOOKING_ID');
+$updateReservationRequest->setBookingId('<BOOKING_ID>');
 
 $updateReservationResult = $bookingResource->updateReservation($updateReservationRequestt);
 
@@ -159,23 +158,20 @@ You can ensure if a booking/reservation was created with:
 
 ### Get a reservation
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
-$reservation = $bookingResource->getReservation('RESERVATION_ID');
+$reservation = $bookingResource->getReservation('<BOOKING_ID>','<RESERVATION_ID>');
 ```
 
 ### Cancel a reservation
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $bookingResource = $katanox->getBookingResource();
 
-$isCancelled = $bookingResource->cancelReservation('RESERVATION_ID');
+$isCancelled = $bookingResource->cancelReservation('<BOOKING_ID>','<RESERVATION_ID>');
 ```
 
 ### Get connected properties
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $propertyResource = $katanox->getPropertyResource();
 
 $properties = $propertyResource->getProperties();
@@ -184,34 +180,30 @@ These are the properties you are connected with.
 
 ### Get a property
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $propertyResource = $katanox->getPropertyResource();
 
-$property= $propertyResource->getProperty('PROPERTY_ID');
+$property= $propertyResource->getProperty('<PROPERTY_ID>');
 ```
 
 ### Get a property 
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true)
 $propertyResource = $katanox->getPropertyResource();
 
-$property= $propertyResource->getProperty('PROPERTY_ID');
+$property= $propertyResource->getProperty('<PROPERTY_ID>');
 ```
 
 ### Get a property unit
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $propertyResource = $katanox->getPropertyResource();
 
-$unit = $propertyResource->getUnit('PROPERTY_ID', 'UNIT_ID');
+$unit = $propertyResource->getUnit('<PROPERTY_ID>', '<UNIT_ID>');
 ```
 
 ### Get a property rate plan
 ``` php
-$katanox = new Katanox\KatanoxApi('your-api-key-here', true);
 $propertyResource = $katanox->getPropertyResource();
 
-$ratePlan = $propertyResource->getRatePlan('PROPERTY_ID', 'RATE_PLAN_ID');
+$ratePlan = $propertyResource->getRatePlan('<PROPERTY_ID>', '<RATE_PLAN_ID>');
 ```
 
 ## Change log

--- a/src/Katanox/KatanoxApi.php
+++ b/src/Katanox/KatanoxApi.php
@@ -19,16 +19,12 @@ class KatanoxApi
     private ?BookingResource $bookingResource = null;
     private ?PropertyResource $propertyResource = null;
 
-    public function __construct(string $apiKey, bool $isSandbox = false)
+    public function __construct(string $apiKey)
     {
         $httpClient = new GuzzleClient(new Client());
-        $baseUrl = 'https://api.katanox.com';
-        if ($isSandbox) {
-            $baseUrl = 'https://api-sandbox.katanox.com';
-        }
-        $this->availabilityResource = new AvailabilityResource($httpClient, $baseUrl, $apiKey);
-        $this->bookingResource = new BookingResource($httpClient, $baseUrl, $apiKey);
-        $this->propertyResource = new PropertyResource($httpClient, $baseUrl, $apiKey);
+        $this->availabilityResource = new AvailabilityResource($httpClient, $apiKey);
+        $this->bookingResource = new BookingResource($httpClient, $apiKey);
+        $this->propertyResource = new PropertyResource($httpClient, $apiKey);
     }
 
     public function getAvailabilityResource(): AvailabilityResource

--- a/src/Katanox/Model/Availability.php
+++ b/src/Katanox/Model/Availability.php
@@ -7,6 +7,10 @@ use Katanox\KatanoxRequest;
 class Availability implements \JsonSerializable
 {
     /**
+     * @var KatanoxRequest the original request that generated this data
+     */
+    protected $request;
+    /**
      * @var AvailabilityData
      */
     private $data;
@@ -20,11 +24,6 @@ class Availability implements \JsonSerializable
      * @var AvailabilityLinks
      */
     private $links;
-
-    /**
-     * @var KatanoxRequest the original request that generated this data
-     */
-    protected $request;
 
     public function __construct()
     {

--- a/src/Katanox/Model/AvailabilityData.php
+++ b/src/Katanox/Model/AvailabilityData.php
@@ -19,11 +19,11 @@ class AvailabilityData
 
     /**
      * @param Property[] $properties
-     * @return AvailabilityData
      */
     public function setProperties(array $properties): AvailabilityData
     {
         $this->properties = $properties;
+
         return $this;
     }
 }

--- a/src/Katanox/Model/Location.php
+++ b/src/Katanox/Model/Location.php
@@ -19,39 +19,27 @@ class Location implements JsonSerializable
         $this->longitude = $longitude;
     }
 
-    /**
-     * @return float
-     */
     public function getLatitude(): float
     {
         return $this->latitude;
     }
 
-    /**
-     * @param float $latitude
-     * @return Location
-     */
     public function setLatitude(float $latitude): Location
     {
         $this->latitude = $latitude;
+
         return $this;
     }
 
-    /**
-     * @return float
-     */
     public function getLongitude(): float
     {
         return $this->longitude;
     }
 
-    /**
-     * @param float $longitude
-     * @return Location
-     */
     public function setLongitude(float $longitude): Location
     {
         $this->longitude = $longitude;
+
         return $this;
     }
 
@@ -59,7 +47,7 @@ class Location implements JsonSerializable
     {
         return [
             'latitude' => $this->latitude,
-            'longitude' => $this->longitude
+            'longitude' => $this->longitude,
         ];
     }
 

--- a/src/Katanox/Model/RatePlanPolicy.php
+++ b/src/Katanox/Model/RatePlanPolicy.php
@@ -22,75 +22,51 @@ class RatePlanPolicy implements JsonSerializable
         $this->amount = $amount;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     * @return RatePlanPolicy
-     */
     public function setName(string $name): RatePlanPolicy
     {
         $this->name = $name;
+
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     * @return RatePlanPolicy
-     */
     public function setDescription(string $description): RatePlanPolicy
     {
         $this->description = $description;
+
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getChargeType(): string
     {
         return $this->charge_type;
     }
 
-    /**
-     * @param string $charge_type
-     * @return RatePlanPolicy
-     */
     public function setChargeType(string $charge_type): RatePlanPolicy
     {
         $this->charge_type = $charge_type;
+
         return $this;
     }
 
-    /**
-     * @return float
-     */
     public function getAmount(): float
     {
         return $this->amount;
     }
 
-    /**
-     * @param float $amount
-     * @return RatePlanPolicy
-     */
     public function setAmount(float $amount): RatePlanPolicy
     {
         $this->amount = $amount;
+
         return $this;
     }
 
@@ -100,7 +76,7 @@ class RatePlanPolicy implements JsonSerializable
             'name' => $this->name,
             'description' => $this->description,
             'charge_type' => $this->charge_type,
-            'amount' => $this->amount
+            'amount' => $this->amount,
         ];
     }
 

--- a/src/Katanox/Model/Unit.php
+++ b/src/Katanox/Model/Unit.php
@@ -125,7 +125,7 @@ class Unit implements JsonSerializable
             'description' => $this->description,
             'images' => $this->images,
             'translations' => $this->translations,
-            'amenities' => $this->amenities
+            'amenities' => $this->amenities,
         ];
     }
 

--- a/src/Katanox/Resource/AvailabilityResource.php
+++ b/src/Katanox/Resource/AvailabilityResource.php
@@ -13,7 +13,7 @@ use Katanox\Model\Query\AvailabilityQuery;
 
 class AvailabilityResource
 {
-    public const RESOURCE_ENDPOINT = 'v1/availability';
+    public const BASE_URL = 'https://api.katanox.com/v1/availability';
     /**
      * @var null|Availability stores the last request made to Endpoint
      */
@@ -26,20 +26,15 @@ class AvailabilityResource
     /**
      * @var string
      */
-    private $baseUrl;
-    /**
-     * @var string
-     */
     private $apiKey;
     /**
      * @var JsonMapper
      */
     private $mapper;
 
-    public function __construct(Client $client, string $baseUrl, string $apiKey)
+    public function __construct(Client $client, string $apiKey)
     {
         $this->client = $client;
-        $this->baseUrl = $baseUrl;
         $this->apiKey = $apiKey;
         $this->mapper = new JsonMapper();
         $this->mapper->bStrictNullTypes = false;
@@ -60,7 +55,7 @@ class AvailabilityResource
         $query->validate();
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT),
+            self::BASE_URL,
             $this->apiKey,
             $query->toArray()
         );

--- a/src/Katanox/Resource/BookingResource.php
+++ b/src/Katanox/Resource/BookingResource.php
@@ -19,18 +19,16 @@ use Katanox\Model\RequestResult\GetReservationResult;
 
 class BookingResource
 {
-    public const RESOURCE_ENDPOINT = 'v1/bookings';
+    public const BASE_URL = 'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings';
 
-    private string $baseUrl;
     private string $apiKey;
     private Client $client;
     private $mapper;
 
-    public function __construct(Client $client, string $baseUrl, string $apiKey)
+    public function __construct(Client $client, string $apiKey)
     {
         $this->client = $client;
         $this->apiKey = $apiKey;
-        $this->baseUrl = $baseUrl;
         $this->mapper = new JsonMapper();
         $this->mapper->bStrictNullTypes = false;
         $this->mapper->bIgnoreVisibility = true;
@@ -48,7 +46,7 @@ class BookingResource
         $booking->validate();
         $req = new KatanoxRequest(
             'POST',
-            sprintf('%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT),
+            self::BASE_URL,
             $this->apiKey,
             $booking->toArray()
         );
@@ -90,7 +88,7 @@ class BookingResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $bookingId),
+            sprintf('%s/%s', self::BASE_URL, $bookingId),
             $this->apiKey,
             []
         );
@@ -130,7 +128,7 @@ class BookingResource
     {
         $req = new KatanoxRequest(
             'DELETE',
-            sprintf('%s/%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $bookingId),
+            sprintf('%s/%s', self::BASE_URL, $bookingId),
             $this->apiKey,
             []
         );
@@ -155,7 +153,7 @@ class BookingResource
         $createReservationRequest->validate();
         $req = new KatanoxRequest(
             'POST',
-            sprintf('%s/%s/%s/reservations', $this->baseUrl, self::RESOURCE_ENDPOINT, $createReservationRequest->getBookingId()),
+            sprintf('%s/%s/reservations', self::BASE_URL, $createReservationRequest->getBookingId()),
             $this->apiKey,
             $createReservationRequest->getReservation()->toArray()
         );
@@ -199,9 +197,8 @@ class BookingResource
     {
         $updateReservationRequest->validate();
         $url = sprintf(
-            '%s/%s/%s/reservations/%s',
-            $this->baseUrl,
-            self::RESOURCE_ENDPOINT,
+            '%s/%s/reservations/%s',
+            self::BASE_URL,
             $updateReservationRequest->getBookingId(),
             $updateReservationRequest->getReservation()->getId()
         );
@@ -251,7 +248,7 @@ class BookingResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s/%s/reservations/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $bookingId, $reservationId),
+            sprintf('%s/%s/reservations/%s', self::BASE_URL, $bookingId, $reservationId),
             $this->apiKey,
             []
         );
@@ -291,7 +288,7 @@ class BookingResource
     {
         $req = new KatanoxRequest(
             'DELETE',
-            sprintf('%s/%s/%s/reservations/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $bookingId, $reservationId),
+            sprintf('%s/%s/reservations/%s', self::BASE_URL, $bookingId, $reservationId),
             $this->apiKey,
             []
         );

--- a/src/Katanox/Resource/BookingResource.php
+++ b/src/Katanox/Resource/BookingResource.php
@@ -19,7 +19,7 @@ use Katanox\Model\RequestResult\GetReservationResult;
 
 class BookingResource
 {
-    public const BASE_URL = 'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings';
+    public const BASE_URL = 'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0';
 
     private string $apiKey;
     private Client $client;

--- a/src/Katanox/Resource/BookingResource.php
+++ b/src/Katanox/Resource/BookingResource.php
@@ -19,7 +19,7 @@ use Katanox\Model\RequestResult\GetReservationResult;
 
 class BookingResource
 {
-    public const BASE_URL = 'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0';
+    public const BASE_URL = 'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings';
 
     private string $apiKey;
     private Client $client;

--- a/src/Katanox/Resource/PropertyResource.php
+++ b/src/Katanox/Resource/PropertyResource.php
@@ -14,18 +14,16 @@ use Katanox\Model\Unit;
 
 class PropertyResource
 {
-    public const RESOURCE_ENDPOINT = 'v1/properties';
+    public const BASE_URL = 'https://api.katanox.com/v1/properties';
 
-    private string $baseUrl;
     private string $apiKey;
     private Client $client;
     private JsonMapper $mapper;
 
-    public function __construct(Client $client, string $baseUrl, string $apiKey)
+    public function __construct(Client $client, string $apiKey)
     {
         $this->client = $client;
         $this->apiKey = $apiKey;
-        $this->baseUrl = $baseUrl;
         $this->mapper = new JsonMapper();
         $this->mapper->bStrictNullTypes = false;
         $this->mapper->bIgnoreVisibility = true;
@@ -41,7 +39,7 @@ class PropertyResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT),
+            self::BASE_URL,
             $this->apiKey,
             []
         );
@@ -78,7 +76,7 @@ class PropertyResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $propertyId),
+            sprintf('%s/%s', self::BASE_URL, $propertyId),
             $this->apiKey,
             []
         );
@@ -113,7 +111,7 @@ class PropertyResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s/%s/units/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $propertyId, $unitId),
+            sprintf('%s/%s/units/%s', self::BASE_URL, $propertyId, $unitId),
             $this->apiKey,
             []
         );
@@ -148,7 +146,7 @@ class PropertyResource
     {
         $req = new KatanoxRequest(
             'GET',
-            sprintf('%s/%s/%s/rate-plans/%s', $this->baseUrl, self::RESOURCE_ENDPOINT, $propertyId, $ratePlanId),
+            sprintf('%s/%s/rate-plans/%s', self::BASE_URL, $propertyId, $ratePlanId),
             $this->apiKey,
             []
         );

--- a/tests/Katanox/Resource/AvailabilityResourceTest.php
+++ b/tests/Katanox/Resource/AvailabilityResourceTest.php
@@ -122,7 +122,7 @@ class AvailabilityResourceTest extends TestCase
             ->andReturn(new Response(
                 200,
                 [],
-                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
+                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]).'invalidjsonline'
             ))
         ;
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
@@ -167,12 +167,14 @@ class AvailabilityResourceTest extends TestCase
                     'property_ids' => null,
                 ],
             ])
-            ->andReturn(new Response(
+            ->andReturn(
+                new Response(
                 200,
                 [],
                 json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
-                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]).'invalidjsonline'
-            ))
+            ),
+                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
+            )
         ;
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();

--- a/tests/Katanox/Resource/AvailabilityResourceTest.php
+++ b/tests/Katanox/Resource/AvailabilityResourceTest.php
@@ -66,7 +66,7 @@ class AvailabilityResourceTest extends TestCase
                 new Response(200, [], json_encode(['data' => ['properties' => [$property]], 'meta' => $metaData, 'links' => $link]))
             )
         ;
-        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'https://api.katanox.com', 'abc');
+        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
             ->setCheckOut('2021-07-10')
@@ -125,7 +125,7 @@ class AvailabilityResourceTest extends TestCase
                 json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
             ))
         ;
-        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'https://api.katanox.com', 'abc');
+        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
             ->setCheckOut('2021-07-10')
@@ -171,9 +171,10 @@ class AvailabilityResourceTest extends TestCase
                 200,
                 [],
                 json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
+                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]).'invalidjsonline'
             ))
         ;
-        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'https://api.katanox.com', 'abc');
+        $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
             ->setChildren(0)

--- a/tests/Katanox/Resource/AvailabilityResourceTest.php
+++ b/tests/Katanox/Resource/AvailabilityResourceTest.php
@@ -64,8 +64,7 @@ class AvailabilityResourceTest extends TestCase
             ])
             ->andReturn(
                 new Response(200, [], json_encode(['data' => ['properties' => [$property]], 'meta' => $metaData, 'links' => $link]))
-            )
-        ;
+            );
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
@@ -76,8 +75,7 @@ class AvailabilityResourceTest extends TestCase
             ->setLng(0.00002)
             ->setRadius(10000)
             ->setPage(1)
-            ->setLimit(25)
-        ;
+            ->setLimit(25);
         $res = $this->availabilityResource->search($q);
 
         $this->assertObjectHasAttribute('prices', $res->getData()->getProperties()[0]);
@@ -99,6 +97,11 @@ class AvailabilityResourceTest extends TestCase
         $this->expectException(KatanoxException::class);
         $property = $this->buildPropertyObject();
         $mockHttpClient = \Mockery::mock(Client::class);
+        $responseBody = json_encode([
+                'data' => ['properties' => [$property]],
+                'metas' => [],
+                'links' => []
+            ]).'invalidjsonline';
         $mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
@@ -122,9 +125,8 @@ class AvailabilityResourceTest extends TestCase
             ->andReturn(new Response(
                 200,
                 [],
-                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]).'invalidjsonline'
-            ))
-        ;
+                $responseBody
+            ));
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
@@ -133,8 +135,7 @@ class AvailabilityResourceTest extends TestCase
             ->setChildren(0)
             ->setLat(0.00001)
             ->setLng(0.00002)
-            ->setRadius(10000)
-        ;
+            ->setRadius(10000);
         $this->availabilityResource->search($q);
     }
 
@@ -147,6 +148,11 @@ class AvailabilityResourceTest extends TestCase
         $this->expectException(MissingParametersException::class);
         $property = $this->buildPropertyObject();
         $mockHttpClient = \Mockery::mock(Client::class);
+        $responseBody = json_encode([
+                'data' => ['properties' => [$property]],
+                'metas' => [],
+                'links' => []
+            ]).'invalidjsonline';
         $mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
@@ -168,20 +174,13 @@ class AvailabilityResourceTest extends TestCase
                 ],
             ])
             ->andReturn(
-                new Response(
-                200,
-                [],
-                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
-            ),
-                json_encode(['data' => ['properties' => [$property]], 'metas' => [], 'link' => []]) . 'invalidjsonline'
-            )
-        ;
+                new Response(200, [], $responseBody)
+            );
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
             ->setChildren(0)
-            ->setRadius(10000)
-        ;
+            ->setRadius(10000);
         $this->availabilityResource->search($q);
     }
 
@@ -197,8 +196,7 @@ class AvailabilityResourceTest extends TestCase
             ])
             ->setAmenities([
                 new Facility('Room amenities', 'Sofa Bed'),
-            ])
-        ;
+            ]);
         $ratePlan = new RatePlan();
         $ratePlan->setId('REW2H24G')
             ->setName('Best Available Rate')
@@ -208,8 +206,7 @@ class AvailabilityResourceTest extends TestCase
             )
             ->setNoShowPolicy(
                 new RatePlanPolicy('No Show Policy', 'The full rate is charged in case of a no show', 'percentage', 100)
-            )
-        ;
+            );
         $property = new Property();
 
         return $property->setId('ABCDEFG')

--- a/tests/Katanox/Resource/AvailabilityResourceTest.php
+++ b/tests/Katanox/Resource/AvailabilityResourceTest.php
@@ -64,7 +64,8 @@ class AvailabilityResourceTest extends TestCase
             ])
             ->andReturn(
                 new Response(200, [], json_encode(['data' => ['properties' => [$property]], 'meta' => $metaData, 'links' => $link]))
-            );
+            )
+        ;
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
@@ -75,7 +76,8 @@ class AvailabilityResourceTest extends TestCase
             ->setLng(0.00002)
             ->setRadius(10000)
             ->setPage(1)
-            ->setLimit(25);
+            ->setLimit(25)
+        ;
         $res = $this->availabilityResource->search($q);
 
         $this->assertObjectHasAttribute('prices', $res->getData()->getProperties()[0]);
@@ -98,10 +100,10 @@ class AvailabilityResourceTest extends TestCase
         $property = $this->buildPropertyObject();
         $mockHttpClient = \Mockery::mock(Client::class);
         $responseBody = json_encode([
-                'data' => ['properties' => [$property]],
-                'metas' => [],
-                'links' => []
-            ]).'invalidjsonline';
+            'data' => ['properties' => [$property]],
+            'metas' => [],
+            'links' => [],
+        ]) . 'invalidjsonline';
         $mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
@@ -126,7 +128,8 @@ class AvailabilityResourceTest extends TestCase
                 200,
                 [],
                 $responseBody
-            ));
+            ))
+        ;
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
@@ -135,7 +138,8 @@ class AvailabilityResourceTest extends TestCase
             ->setChildren(0)
             ->setLat(0.00001)
             ->setLng(0.00002)
-            ->setRadius(10000);
+            ->setRadius(10000)
+        ;
         $this->availabilityResource->search($q);
     }
 
@@ -149,10 +153,10 @@ class AvailabilityResourceTest extends TestCase
         $property = $this->buildPropertyObject();
         $mockHttpClient = \Mockery::mock(Client::class);
         $responseBody = json_encode([
-                'data' => ['properties' => [$property]],
-                'metas' => [],
-                'links' => []
-            ]).'invalidjsonline';
+            'data' => ['properties' => [$property]],
+            'metas' => [],
+            'links' => [],
+        ]) . 'invalidjsonline';
         $mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
@@ -175,12 +179,14 @@ class AvailabilityResourceTest extends TestCase
             ])
             ->andReturn(
                 new Response(200, [], $responseBody)
-            );
+            )
+        ;
         $this->availabilityResource = new AvailabilityResource($mockHttpClient, 'abc');
         $q = new AvailabilityQuery();
         $q->setCheckIn('2021-07-08')
             ->setChildren(0)
-            ->setRadius(10000);
+            ->setRadius(10000)
+        ;
         $this->availabilityResource->search($q);
     }
 
@@ -196,7 +202,8 @@ class AvailabilityResourceTest extends TestCase
             ])
             ->setAmenities([
                 new Facility('Room amenities', 'Sofa Bed'),
-            ]);
+            ])
+        ;
         $ratePlan = new RatePlan();
         $ratePlan->setId('REW2H24G')
             ->setName('Best Available Rate')
@@ -206,7 +213,8 @@ class AvailabilityResourceTest extends TestCase
             )
             ->setNoShowPolicy(
                 new RatePlanPolicy('No Show Policy', 'The full rate is charged in case of a no show', 'percentage', 100)
-            );
+            )
+        ;
         $property = new Property();
 
         return $property->setId('ABCDEFG')

--- a/tests/Katanox/Resource/BookingResourceTest.php
+++ b/tests/Katanox/Resource/BookingResourceTest.php
@@ -30,7 +30,7 @@ class BookingResourceTest extends TestCase
     public function setUp(): void
     {
         $this->mockHttpClient = \Mockery::mock(Client::class);
-        $this->bookingResource = new BookingResource($this->mockHttpClient, 'https://api.katanox.com', 'abc');
+        $this->bookingResource = new BookingResource($this->mockHttpClient, 'abc');
     }
 
     /**
@@ -54,7 +54,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.katanox.com/v1/bookings',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -139,7 +139,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.katanox.com/v1/bookings',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -226,7 +226,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.katanox.com/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -253,7 +253,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.katanox.com/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -275,7 +275,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.katanox.com/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -295,7 +295,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.katanox.com/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -330,7 +330,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations',
                 'abc',
                 [
                     'guests' => [
@@ -402,7 +402,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [
                     'guests' => [
@@ -469,7 +469,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -500,7 +500,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -523,7 +523,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -543,7 +543,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.katanox.com/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])

--- a/tests/Katanox/Resource/BookingResourceTest.php
+++ b/tests/Katanox/Resource/BookingResourceTest.php
@@ -54,7 +54,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -139,7 +139,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -226,7 +226,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
                 'abc',
                 [],
             ])
@@ -253,7 +253,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
                 'abc',
                 [],
             ])
@@ -275,7 +275,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
                 'abc',
                 [],
             ])
@@ -295,7 +295,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
                 'abc',
                 [],
             ])
@@ -330,7 +330,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations',
                 'abc',
                 [
                     'guests' => [
@@ -402,7 +402,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
                 'abc',
                 [
                     'guests' => [
@@ -469,7 +469,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -500,7 +500,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -523,7 +523,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -543,7 +543,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])

--- a/tests/Katanox/Resource/BookingResourceTest.php
+++ b/tests/Katanox/Resource/BookingResourceTest.php
@@ -54,7 +54,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -139,7 +139,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings',
                 'abc',
                 [
                     'total_price' => 1.0,
@@ -226,7 +226,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -253,7 +253,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -275,7 +275,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -295,7 +295,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE',
                 'abc',
                 [],
             ])
@@ -330,7 +330,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations',
                 'abc',
                 [
                     'guests' => [
@@ -402,7 +402,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'POST',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [
                     'guests' => [
@@ -469,7 +469,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -500,7 +500,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'GET',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -523,7 +523,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])
@@ -543,7 +543,7 @@ class BookingResourceTest extends TestCase
         $this->mockHttpClient->shouldReceive('request')
             ->withArgs([
                 'DELETE',
-                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/ABCDE/reservations/ABCDE',
+                'https://api.pci-proxy.com/v1/push/5775c7cf3b3e5dc0/v1/bookings/ABCDE/reservations/ABCDE',
                 'abc',
                 [],
             ])

--- a/tests/Katanox/Resource/PropertyResourceTest.php
+++ b/tests/Katanox/Resource/PropertyResourceTest.php
@@ -28,7 +28,7 @@ class PropertyResourceTest extends TestCase
     public function setUp(): void
     {
         $this->mockHttpClient = \Mockery::mock(Client::class);
-        $this->propertyResource = new PropertyResource($this->mockHttpClient, 'https://api.katanox.com', 'abc');
+        $this->propertyResource = new PropertyResource($this->mockHttpClient, 'abc');
     }
 
     public function testFetchPropertiesSuccess()
@@ -46,7 +46,8 @@ class PropertyResourceTest extends TestCase
                     [],
                     json_encode(['data' => ['property' => [$this->buildPropertyObject()]]])
                 )
-            );
+            )
+        ;
 
         $res = $this->propertyResource->getProperties();
         $this->assertCount(1, $res->getProperties());
@@ -194,6 +195,7 @@ class PropertyResourceTest extends TestCase
     private function buildUnit(): Unit
     {
         $unit = new Unit();
+
         return $unit->setId('ABC456FG')
             ->setName('Room with a Balcony')
             ->setDescription('Great room with sea view')
@@ -203,12 +205,14 @@ class PropertyResourceTest extends TestCase
             ])
             ->setAmenities([
                 new Facility('Room amenities', 'Sofa Bed'),
-            ]);
+            ])
+        ;
     }
 
     private function buildRatePlan(): RatePlan
     {
         $ratePlan = new RatePlan();
+
         return $ratePlan->setId('REW2H24G')
             ->setName('Best Available Rate')
             ->setDescription('Best rate for this room')
@@ -217,7 +221,8 @@ class PropertyResourceTest extends TestCase
             )
             ->setNoShowPolicy(
                 new RatePlanPolicy('No Show Policy', 'The full rate is charged in case of a no show', 'percentage', 100)
-            );
+            )
+        ;
     }
 
     private function buildPropertyObject(): Property


### PR DESCRIPTION
## Description

In this PR, we update the way the KatanoxApi object is created. Moreover, we changed the booking resource base url to use the PCI Proxy url to achieve PCI compliance.

## Motivation and context

Since we updated our sandbox implementation to make it simpler and easier to use for our users, there is no need for a different endpoint when accessing sandbox.

Instead you can use the sandbox api key provided in the platform and the API will infer the context by it.

## How has this been tested?

Unit tests are updated and passing.

## Types of changes

What types of changes does your code introduce? 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
