### PR TITLE
URL encode query parameters

### DIFF
--- a/src/Katanox/Http/GuzzleClient.php
+++ b/src/Katanox/Http/GuzzleClient.php
@@ -4,7 +4,6 @@ namespace Katanox\Http;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Katanox\Exceptions\HttpException;
@@ -38,7 +37,7 @@ final class GuzzleClient implements Client
 
             if ($method === 'GET') {
                 $query = http_build_query($data, null, '&');
-                $options['body'] = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
+                $options['body'] = preg_replace('/%5B(?:\d|[1-9]\d+)%5D=/', '=', $query);
             } else {
                 $options['json'] = $data;
             }

--- a/src/Katanox/Http/GuzzleClient.php
+++ b/src/Katanox/Http/GuzzleClient.php
@@ -37,7 +37,8 @@ final class GuzzleClient implements Client
             ];
 
             if ($method === 'GET') {
-                $options['body'] = Query::build($data, PHP_QUERY_RFC1738);
+                $query = http_build_query($data, null, '&');
+                $options['body'] = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
             } else {
                 $options['json'] = $data;
             }

--- a/src/Katanox/Http/GuzzleClient.php
+++ b/src/Katanox/Http/GuzzleClient.php
@@ -4,6 +4,7 @@ namespace Katanox\Http;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Katanox\Exceptions\HttpException;
@@ -36,15 +37,14 @@ final class GuzzleClient implements Client
             ];
 
             if ($method === 'GET') {
-                $query = http_build_query($data, null, '&');
-                $options['body'] = preg_replace('/%5B(?:\d|[1-9]\d+)%5D=/', '=', $query);
+                $options['body'] = Query::build($data, PHP_QUERY_RFC1738);
             } else {
                 $options['json'] = $data;
             }
 
 
             if ($params) {
-                $options['query'] = $params;
+                $options['query'] = Query::build($data, PHP_QUERY_RFC1738);
             }
 
             $headers['Authorization'] = sprintf('Bearer %s', $apiKey);

--- a/src/Katanox/Http/GuzzleClient.php
+++ b/src/Katanox/Http/GuzzleClient.php
@@ -44,7 +44,7 @@ final class GuzzleClient implements Client
 
 
             if ($params) {
-                $options['query'] = Query::build($data, PHP_QUERY_RFC1738);
+                $options['query'] = Query::build($params, PHP_QUERY_RFC1738);
             }
 
             $headers['Authorization'] = sprintf('Bearer %s', $apiKey);

--- a/src/Katanox/Model/Query/AvailabilityQuery.php
+++ b/src/Katanox/Model/Query/AvailabilityQuery.php
@@ -278,9 +278,9 @@ class AvailabilityQuery
             'radius' => $this->getRadius(),
             'page' => $this->getPage(),
             'limit' => $this->getLimit(),
-            'include' => $this->getInclude() !== null ? implode(',', $this->getInclude()) : null,
+            'include' => $this->getInclude(),
             'locale' => $this->getLocale(),
-            'property_ids' => $this->getPropertyIds() !== null ? implode(',', $this->getPropertyIds()) : null,
+            'property_ids' => $this->getPropertyIds(),
         ];
     }
 


### PR DESCRIPTION
## Description

Fix array query fields encoding.

## Motivation and context

Currently the params option of the guzzle client was not being built using the `GuzzleHttp\Psr7\Query::build` function, and therefore arrays were not properly encoded.

## How has this been tested?
Automated Tests

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
